### PR TITLE
Fix building | EXTCOMIN behaviour | LCD backlight scaling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/rhulme/pico-flashloader.git
 [submodule "pico-extras"]
 	path = 3rdparty/pico-extras
-	url = git@github.com:ardangelo/pico-extras.git
+	url = https://github.com/raspberrypi/pico-extras.git

--- a/app/backlight.c
+++ b/app/backlight.c
@@ -3,34 +3,38 @@
 
 #include <hardware/pwm.h>
 #include <pico/stdlib.h>
+#include <stdio.h>
 
-void backlight_sync(void)
-{
-	pwm_set_gpio_level(PIN_BKL, reg_get_value(REG_ID_BKL)  * 0x80);
-    #ifdef PIN_LCDBL_DRV
-	pwm_set_gpio_level(PIN_LCDBL_DRV, reg_get_value(REG_ID_BKL)  * 0x80);
-    #endif
+void backlight_sync(void) {
+  pwm_set_gpio_level(PIN_BKL, reg_get_value(REG_ID_BKL) * 0x80);
+#ifdef PIN_LCDBL_DRV
+  // the given LCD backlight level ranges from 0 to 255 and needs
+  // to scale from 0 to (2^16)-1 (max uint16_t), so the scaling factor
+  // required is:
+  // (2^16)-1 / 255 = 257 = 0x101
+  uint16_t lcdbl_drv = reg_get_value(REG_ID_BK2) * 0x101;
+  printf("set lcdbl_drv=%d\n", lcdbl_drv);
+  pwm_set_gpio_level(PIN_LCDBL_DRV, lcdbl_drv);
+#endif
 }
 
-void backlight_init(void)
-{
-	gpio_set_function(PIN_BKL, GPIO_FUNC_PWM);
+void backlight_init(void) {
+  gpio_set_function(PIN_BKL, GPIO_FUNC_PWM);
 
-	const uint slice_num = pwm_gpio_to_slice_num(PIN_BKL);
+  const uint slice_num = pwm_gpio_to_slice_num(PIN_BKL);
 
-	pwm_config config = pwm_get_default_config();
-	pwm_init(slice_num, &config, true);
+  pwm_config config = pwm_get_default_config();
+  pwm_init(slice_num, &config, true);
 
-    #ifdef PIN_LCDBL_DRV
-	//display
+#ifdef PIN_LCDBL_DRV
+  // display
 
-	gpio_set_function(PIN_LCDBL_DRV, GPIO_FUNC_PWM);
+  gpio_set_function(PIN_LCDBL_DRV, GPIO_FUNC_PWM);
 
-	const uint slice_num2 = pwm_gpio_to_slice_num(PIN_LCDBL_DRV);
+  const uint slice_num2 = pwm_gpio_to_slice_num(PIN_LCDBL_DRV);
+  pwm_config config2 = pwm_get_default_config();
+  pwm_init(slice_num2, &config2, true);
+#endif
 
-	pwm_config config2 = pwm_get_default_config();
-	pwm_init(slice_num2, &config2, true);
-    #endif
-
-	backlight_sync();
+  backlight_sync();
 }

--- a/app/peripherals.c
+++ b/app/peripherals.c
@@ -2,154 +2,151 @@
 Blepis-only file
 */
 
-#include "reg.h"
-#include "gpio.h"
 #include "peripherals.h"
+#include "gpio.h"
+#include "reg.h"
 
-#include <stdio.h>
 #include <hardware/pwm.h>
 #include <pico/stdlib.h>
+#include <stdio.h>
 
-alarm_id_t g_extcomin_alarm = -1;
-uint32_t extcomin_alarm_ms = 500;
+static int64_t extcomin_start_after_initial_delay(alarm_id_t _, void *__);
+static bool extcomin_repeating_timer(repeating_timer_t *rt);
 
-static int64_t extcomin_alarm_callback(alarm_id_t _, void* __);
+void peripherals_init(void) {
+  // charging pins
+  uni_gpio_set_dir(PIN_CHG_DIS, GPIO_OUT);
+  charger_enable();
+  uni_gpio_set_dir(PIN_CHG_PWR, GPIO_OUT);
+  charger_lopwr();
 
-void peripherals_init(void)
-{
-    // charging pins
-	uni_gpio_set_dir(PIN_CHG_DIS, GPIO_OUT);
-    charger_enable();
-	uni_gpio_set_dir(PIN_CHG_PWR, GPIO_OUT);
-    charger_lopwr();
-    #ifdef BLEPIS_V2
-    // 5v boost
-	uni_gpio_set_dir(PIN_5V_BOOST_EN, GPIO_OUT);
-    boost_disable();
-    // uart mux
-	uni_gpio_set_dir(PIN_UART_MUX_SEL, GPIO_OUT);
-    uartmux_exp();
-    #endif
-    // usb and fusb muxes
-    usbmux_rp2040();
-	uni_gpio_set_dir(PIN_USB_MUX_SEL, GPIO_OUT);
-    // setting FUSB mux SEL to out before setting it high means FUSB would momentarily disappear from the bus.
-    // however, on stock blepis v1, this means Zero and 2040 I2C buses getting short-circuit, which, is pretty bad and undesirable
-    // which is why here I set value first and then init.
-    fusbmux_rp2040();
-	uni_gpio_set_dir(PIN_FUSB_MUX_SEL, GPIO_OUT);
-    // extin
-    uni_gpio_set_dir(PIN_DISP_EXTIN, GPIO_OUT);
-    //uni_gpio_put(PIN_DISP_EXTIN, 0);
-    g_extcomin_alarm = 1;
-    (void)extcomin_alarm_callback(0, NULL);
+#ifdef BLEPIS_V2
+  // 5v boost
+  uni_gpio_set_dir(PIN_5V_BOOST_EN, GPIO_OUT);
+  boost_disable();
+  // uart mux
+  uni_gpio_set_dir(PIN_UART_MUX_SEL, GPIO_OUT);
+  uartmux_exp();
+#endif
+
+  // usb and fusb muxes
+  usbmux_rp2040();
+  uni_gpio_set_dir(PIN_USB_MUX_SEL, GPIO_OUT);
+
+  // setting FUSB mux SEL to out before setting it high means FUSB
+  // would momentarily disappear from the bus.
+  // however, on stock blepis v1, this means Zero and 2040 I2C buses
+  // getting short-circuit, which, is pretty bad and undesirable
+  // which is why here I set value first and then init.
+  fusbmux_rp2040();
+  uni_gpio_set_dir(PIN_FUSB_MUX_SEL, GPIO_OUT);
+
+  // extin
+  // -> reproduce exact behaviour in sharp-drm driver
+  uni_gpio_set_dir(PIN_DISP_EXTIN, GPIO_OUT);
+  add_alarm_in_ms(500, extcomin_start_after_initial_delay, NULL, true);
 }
 
 #ifdef BLEPIS_V2
-void boost_enable()
-{
-    //printf("boost en\r\n");
-	uni_gpio_put(PIN_5V_BOOST_EN, 1);
+void boost_enable() {
+  // printf("boost en\r\n");
+  uni_gpio_put(PIN_5V_BOOST_EN, 1);
 }
 
-void boost_disable()
-{
-    //printf("boost dis\r\n");
-	uni_gpio_put(PIN_5V_BOOST_EN, 0);
+void boost_disable() {
+  // printf("boost dis\r\n");
+  uni_gpio_put(PIN_5V_BOOST_EN, 0);
 }
 
 #endif
 
-void charger_enable()
-{
-    //printf("chg en\r\n");
-	uni_gpio_put(PIN_CHG_DIS, 0);
+void charger_enable() {
+  // printf("chg en\r\n");
+  uni_gpio_put(PIN_CHG_DIS, 0);
 }
 
-void charger_disable()
-{
-    //printf("chg dis\r\n");
-	uni_gpio_put(PIN_CHG_DIS, 1);
+void charger_disable() {
+  // printf("chg dis\r\n");
+  uni_gpio_put(PIN_CHG_DIS, 1);
 }
 
-
-void charger_lopwr()
-{
-    //printf("chg lpwr\r\n");
-	uni_gpio_put(PIN_CHG_PWR, 0);
+void charger_lopwr() {
+  // printf("chg lpwr\r\n");
+  uni_gpio_put(PIN_CHG_PWR, 0);
 }
 
-void charger_hipwr()
-{
-    //printf("chg hpwr\r\n");
-	uni_gpio_put(PIN_CHG_PWR, 1);
+void charger_hipwr() {
+  // printf("chg hpwr\r\n");
+  uni_gpio_put(PIN_CHG_PWR, 1);
 }
 
-
-void usbmux_host()
-{
-    //printf("usmbux host\r\n");
-    #ifdef BLEPIS_V2
-	uni_gpio_put(PIN_USB_MUX_SEL, 0);
-    #else
-	uni_gpio_put(PIN_USB_MUX_SEL, 1);
-    #endif
+void usbmux_host() {
+  // printf("usmbux host\r\n");
+#ifdef BLEPIS_V2
+  uni_gpio_put(PIN_USB_MUX_SEL, 0);
+#else
+  uni_gpio_put(PIN_USB_MUX_SEL, 1);
+#endif
 }
 
-void usbmux_rp2040()
-{
-    //printf("usmbux rp2040\r\n");
-    #ifdef BLEPIS_V2
-	uni_gpio_put(PIN_USB_MUX_SEL, 1);
-    #else
-	uni_gpio_put(PIN_USB_MUX_SEL, 0);
-    #endif
+void usbmux_rp2040() {
+  // printf("usmbux rp2040\r\n");
+#ifdef BLEPIS_V2
+  uni_gpio_put(PIN_USB_MUX_SEL, 1);
+#else
+  uni_gpio_put(PIN_USB_MUX_SEL, 0);
+#endif
 }
 
-void fusbmux_rp2040()
-{
-    //printf("fusmbux en\r\n");
-	uni_gpio_put(PIN_FUSB_MUX_SEL, 1);
+void fusbmux_rp2040() {
+  // printf("fusmbux en\r\n");
+  uni_gpio_put(PIN_FUSB_MUX_SEL, 1);
 }
 
-void fusbmux_zero()
-{
-    //printf("fusmbux dis\r\n");
-	uni_gpio_put(PIN_FUSB_MUX_SEL, 0);
+void fusbmux_zero() {
+  // printf("fusmbux dis\r\n");
+  uni_gpio_put(PIN_FUSB_MUX_SEL, 0);
 }
 
 #ifdef BLEPIS_V2
 
 // switches uart to external pin header, default
-void uartmux_exp()
-{
-    //printf("uartmux exp\r\n");
-	uni_gpio_put(PIN_UART_MUX_SEL, 1);
+void uartmux_exp() {
+  // printf("uartmux exp\r\n");
+  uni_gpio_put(PIN_UART_MUX_SEL, 1);
 }
 
 // switches uart to internal two pads
-void uartmux_intl()
-{
-    //printf("uartmux intl\r\n");
-	uni_gpio_put(PIN_UART_MUX_SEL, 0);
+void uartmux_intl() {
+  // printf("uartmux intl\r\n");
+  uni_gpio_put(PIN_UART_MUX_SEL, 0);
 }
 
 #endif
 
 // EXTCOMIN driver
+static repeating_timer_t repeating_timer;
 
-static int64_t extcomin_alarm_callback(alarm_id_t _, void* __)
-{
-    static bool extcomin_high = false;
+static int64_t extcomin_start_after_initial_delay(alarm_id_t _, void *__) {
 
-    // Extcomin output disabled?
-    if (g_extcomin_alarm < 0) {
-        return 0;
-    }
+  // run timer once after inital delay
+  extcomin_repeating_timer(NULL);
 
-	uni_gpio_put(PIN_DISP_EXTIN, extcomin_high);
-    extcomin_high = !extcomin_high;
+  // schedule timer to be run with fixed delay from now on
+  add_repeating_timer_ms(1000, extcomin_repeating_timer, NULL,
+                         &repeating_timer);
 
-    g_extcomin_alarm = add_alarm_in_ms(extcomin_alarm_ms, extcomin_alarm_callback, NULL, true);
-    return 0;
+  // do not run again
+  return 0;
+}
+
+static bool extcomin_repeating_timer(repeating_timer_t *rt) {
+  static bool extcomin_high = false;
+
+  // toggle gpio
+  extcomin_high = !extcomin_high;
+  uni_gpio_put(PIN_DISP_EXTIN, extcomin_high);
+
+  // run again
+  return true;
 }

--- a/app/pi.c
+++ b/app/pi.c
@@ -26,8 +26,9 @@
 #include <pico/stdlib.h>
 #include <pico/sleep.h>
 #include <pico/runtime_init.h>
+
 #ifndef NDEBUG
-    #include <stdio.h>
+#include <stdio.h>
 #endif
 
 #define LED_FLASH_CYCLE_MS 3000
@@ -508,6 +509,7 @@ uint8_t dormant_get_reentry_flag(void)
 static void sleep_callback(void)
 {}
 
+#if 0
 void dormant_seconds(int seconds)
 {
 	struct sleep_state ss;
@@ -543,3 +545,4 @@ void dormant_seconds(int seconds)
 	// Restore clocks, LED, backlight
 	sleep_resume(&ss);
 }
+#endif


### PR DESCRIPTION
This PR addresses the following three issues:

- I was unable to build the project directly, since the submodule was not moved yet to the upstream pico-extras.git. In addition, the `rtc_get/set_datetime() functions in `dormant_seconds()` seem to be removed from the newer PICO SDKs. Fortunately, the function was not required, so simply disabling was enough :)
- Making the EXTCOMIN signal behave as the sharp-drm driver expects - not sure if this can cause issues, but while troubleshooting another issue, I came across it
- Fix LCD backlight scaling factor to use the full uint16_t range 0 to (2^16)-1 range for PWM, otherwise the maximum backlight setting is essentially just 50% LCD backlight